### PR TITLE
fix let coverage of lhs (Issue #2)

### DIFF
--- a/errortrace-lib/errortrace/stacktrace.rkt
+++ b/errortrace-lib/errortrace/stacktrace.rkt
@@ -290,12 +290,8 @@
                                      (syntax-case vars () [(id) (syntax id)] [_else #f])
                                      rhs
                                      phase))
-                       (let loop ([names vars] [rhs rhs*])
-                         (cond
-                           [(syntax? names) (loop (syntax-e vars) rhs)]
-                           [(pair? names)
-                            (loop (cdr names) (test-coverage-point rhs (car names) phase))]
-                           [else rhs])))
+                       (for/fold ([rhs rhs*]) ([name (in-list (syntax->list vars))])
+                         (test-coverage-point rhs name phase)))
                      varss
                      rhss)]
               [bodyl (map (lambda (body) (no-cache-annotate body phase))

--- a/errortrace-test/tests/errortrace/coverage-let.rkt
+++ b/errortrace-test/tests/errortrace/coverage-let.rkt
@@ -1,0 +1,35 @@
+#lang racket/base
+
+(provide letrec-test)
+(require errortrace/stacktrace racket/unit tests/eli-tester)
+
+
+(define (with-mark src dest phase) dest)
+(define test-coverage-enabled (make-parameter #t))
+(define profile-key (gensym))
+(define profiling-enabled (make-parameter #f))
+(define initialize-profile-point void)
+(define (register-profile-start . a) #f)
+(define register-profile-done void)
+(define test-coverage-enabled? #t)
+
+(define covered? #f)
+(define initialized? #f)
+(define (test-covered stx)
+  (if (eq? (syntax-e stx) 'x)
+      (lambda () (set! covered? #t))
+      void))
+(define (initialize-test-coverage-point stx)
+  (when (eq? (syntax-e stx) 'x)
+    (set! initialized? #t)))
+(define-values/invoke-unit/infer stacktrace@)
+
+(define (letrec-test)
+  (define test-stx
+    #'(module test racket (letrec ([x (lambda () 0)]) (void))))
+  (define ns (make-base-namespace))
+  (parameterize ([current-namespace ns])
+    (eval (annotate-top (expand test-stx) 0))
+    (eval '(require 'test)))
+  (test initialized? => #t)
+  (test covered? => #t))

--- a/errortrace-test/tests/errortrace/main.rkt
+++ b/errortrace-test/tests/errortrace/main.rkt
@@ -5,11 +5,13 @@
          "alert.rkt"
          "phase-1.rkt"
          "phase-1-eval.rkt"
-         "begin.rkt")
+         "begin.rkt"
+         "coverage-let.rkt")
 
 (wrap-tests)
 
 (test do (alert-tests))
+(test do (letrec-test))
 
 (phase-1-tests)
 (phase-1-eval-tests)


### PR DESCRIPTION
Fixes coverage annotations of `let`s to cover the lhs of bindings before evaluating the rhs. (Issue #2)