### PR TITLE
Phase 1 coverage

### DIFF
--- a/errortrace-doc/errortrace/scribblings/errortrace.scrbl
+++ b/errortrace-doc/errortrace/scribblings/errortrace.scrbl
@@ -372,6 +372,11 @@ the @racket[stacktrace@] unit, its import signature
 Imports @racket[stacktrace-imports^] and exports @racket[stacktrace^].}
 
 
+@defthing[stacktrace/annotator@ unit?]{
+
+Imports @racket[stacktrace/annotator-imports^] and exports @racket[stacktrace^].}
+
+
 @defsignature[stacktrace^ ()]{
 
 @deftogether[(
@@ -488,6 +493,58 @@ Note that @racketin[register-profile-start] and
 @racketin[register-profile-done] can be called in a nested manner; in
 this case, the result of @racketin[register-profile-start] should be
 @racket[#f].}
+
+}
+
+
+@defsignature[stacktrace/annotator-imports^ ()]{
+
+Like @racket[stacktrace^], but providing more control over the annotation function for test
+cases. The only difference between the two signatures is @racket[test-coverage-enabled],
+@racket[initialize-test-coverage-point], and @racket[test-covered] are replaced by
+@racket[test-coverage-point].
+
+@defproc[(test-coverage-point (body syntax?)
+                              (expr syntax?)
+                              (phase exact-integer?))
+        syntax?]{
+
+Initializes the test coverage point for @racket[expr] and returns the syntax that will cover
+it. @racket[body] is the body that should be run after the coverage for @racket[expr] has been
+recorded as covered. @racket[body] and @racket[expr] may not be the same. For example @racket[expr]
+may not have appeared in an expression position. @racket[phase] is the phase level at which
+@racket[expr] appeared. }
+
+@defproc[(with-mark [source-stx any/c]
+                    [dest-stx any/c]
+                    [phase nonnegative-exact-integer?])
+         any/c]{
+Same as in @racket[stacktrace-imports^].}
+
+@defthing[profile-key any/c]{
+
+Same as in @racket[stacktrace-imports^].}
+
+@defboolparam[profiling-enabled on?]{
+
+Same as in @racket[stacktrace-imports^].}
+
+@defproc[(initialize-profile-point (key any/c) 
+                                   (name (or/c syntax? false/c))
+                                   (stx any/c))
+         void?]{
+
+Same as in @racket[stacktrace-imports^].}
+
+@defproc[(register-profile-start (key any/c)) (or/c number? false/c)]{
+
+Same as in @racket[stacktrace-imports^].}
+
+@defproc[(register-profile-done (key any/c)
+                                (start (or/c number? false/c)))
+                                void?]{
+
+Same as @racket[stacktrace-imports^].}
 
 }
 

--- a/errortrace-doc/info.rkt
+++ b/errortrace-doc/info.rkt
@@ -8,4 +8,4 @@
 
 (define pkg-desc "documentation part of \"errortrace\"")
 
-(define pkg-authors '(mflatt))
+(define pkg-authors '(mflatt "spencer@florence.io"))

--- a/errortrace-lib/errortrace/stacktrace.rkt
+++ b/errortrace-lib/errortrace/stacktrace.rkt
@@ -10,13 +10,27 @@
 (define expanded-stx (make-parameter #f))
 (define maybe-undefined (make-parameter #hasheq()))
 
-(provide stacktrace@ stacktrace^ stacktrace-imports^ original-stx expanded-stx)
+(provide stacktrace@ stacktrace^ stacktrace-imports^
+         stacktrace/annotator-imports^ stacktrace/annotator@
+         original-stx expanded-stx)
+
 (define-signature stacktrace-imports^
   (with-mark
    
    test-coverage-enabled
    test-covered
    initialize-test-coverage-point
+   
+   profile-key
+   profiling-enabled
+   initialize-profile-point
+   register-profile-start
+   register-profile-done))
+
+(define-signature stacktrace/annotator-imports^
+  (with-mark
+   
+   test-coverage-point
    
    profile-key
    profiling-enabled
@@ -46,7 +60,37 @@
 (define-unit stacktrace@
   (import stacktrace-imports^)
   (export stacktrace^)
-  
+         ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+  ;; Test case coverage instrumenter
+ 
+  ;; The next procedure is called by `annotate' and `annotate-top' to wrap
+  ;; expressions with test suite coverage information.  Returning the
+  ;; first argument means no tests coverage information is collected.
+ 
+  ;; test-coverage-point : syntax syntax phase -> syntax
+  ;; sets a test coverage point for a single expression
+  (define (test-coverage-point body expr phase)
+    (if (and (test-coverage-enabled)
+             (zero? phase) 
+             (syntax-position expr))
+      (begin (initialize-test-coverage-point expr)
+             (let ([thunk (test-covered expr)])
+               (cond [(procedure? thunk)
+                      (with-syntax ([body body] [thunk thunk])
+                        #'(begin (#%plain-app thunk) body))]
+                     [(syntax? thunk)
+                      (with-syntax ([body body] [thunk thunk])
+                        #'(begin thunk body))]
+                     [else body])))
+      body))
+
+
+  (define-values/invoke-unit/infer stacktrace/annotator@))
+
+(define-unit stacktrace/annotator@
+  (import stacktrace/annotator-imports^)
+  (export stacktrace^)
+
   (define (short-version v depth)
     (cond
       [(identifier? v) (syntax-e v)]
@@ -107,32 +151,6 @@
   (define (st-mark-bindings x) null)
   
   
-       ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-  ;; Test case coverage instrumenter
- 
-  ;; The next procedure is called by `annotate' and `annotate-top' to wrap
-  ;; expressions with test suite coverage information.  Returning the
-  ;; first argument means no tests coverage information is collected.
- 
-  ;; test-coverage-point : syntax syntax phase -> syntax
-  ;; sets a test coverage point for a single expression
-  (define (test-coverage-point body expr phase)
-    (if (and (test-coverage-enabled)
-             (zero? phase)
-             (syntax-position expr))
-      (begin (initialize-test-coverage-point expr)
-             (let ([thunk (test-covered expr)])
-               (cond [(procedure? thunk)
-                      (with-syntax ([body body] [thunk thunk])
-                        #'(begin (#%plain-app thunk) body))]
-                     [(syntax? thunk)
-                      (with-syntax ([body body] [thunk thunk])
-                        #'(begin thunk body))]
-                     [else body])))
-      body))
-
-
-
   ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
   ;; Profiling instrumenter
   

--- a/errortrace-lib/info.rkt
+++ b/errortrace-lib/info.rkt
@@ -5,3 +5,5 @@
 (define pkg-desc "implementation (no documentation) part of \"errortrace\"")
 
 (define pkg-authors '(mflatt))
+
+(define version "1.1")

--- a/errortrace-lib/info.rkt
+++ b/errortrace-lib/info.rkt
@@ -4,6 +4,6 @@
 
 (define pkg-desc "implementation (no documentation) part of \"errortrace\"")
 
-(define pkg-authors '(mflatt))
+(define pkg-authors '(mflatt "spencer@florence.io"))
 
 (define version "1.1")

--- a/errortrace-test/info.rkt
+++ b/errortrace-test/info.rkt
@@ -7,4 +7,4 @@
 
 (define pkg-desc "tests for \"errortrace\"")
 
-(define pkg-authors '(mflatt))
+(define pkg-authors '(mflatt "spencer@florence.io"))

--- a/errortrace-test/tests/errortrace/main.rkt
+++ b/errortrace-test/tests/errortrace/main.rkt
@@ -6,12 +6,14 @@
          "phase-1.rkt"
          "phase-1-eval.rkt"
          "begin.rkt"
-         "coverage-let.rkt")
+         "coverage-let.rkt"
+         "test-compile-time.rkt")
 
 (wrap-tests)
 
 (test do (alert-tests))
 (test do (letrec-test))
+(test do (test-phase-coverage))
 
 (phase-1-tests)
 (phase-1-eval-tests)

--- a/errortrace-test/tests/errortrace/test-compile-time.rkt
+++ b/errortrace-test/tests/errortrace/test-compile-time.rkt
@@ -1,0 +1,69 @@
+#lang racket
+
+(provide test-phase-coverage)
+(require errortrace/stacktrace racket/unit tests/eli-tester)
+
+(define (test-phase-coverage)
+  (test-phase-0-coverage)
+  (test-phase-1-coverage))
+
+(define (with-mark src dest phase) dest)
+(define test-coverage-enabled (make-parameter #t))
+(define profile-key (gensym))
+(define profiling-enabled (make-parameter #f))
+(define initialize-profile-point void)
+(define (register-profile-start . a) #f)
+(define register-profile-done void)
+
+(define (test-phase-0-coverage)
+  (define test-coverage-enabled? #t)
+
+
+  (define covered? #f)
+  (define initialized? #f)
+
+  (define (test-covered stx)
+    (if (eq? (syntax-e stx) 'x)
+        (lambda () (set! covered? #t))
+        void))
+  (define (initialize-test-coverage-point stx)
+    (when (eq? (syntax-e stx) 'x)
+      (set! initialized? #t)))
+
+  (define-values/invoke-unit/infer stacktrace@)
+
+  (define test-stx
+    #'(module test racket (begin-for-syntax (define x 5) x)))
+  (define ns (make-base-namespace))
+  (parameterize ([current-namespace ns])
+    (eval (annotate-top (expand test-stx) 0))
+    (eval '(require 'test)))
+  (test initialized? => #f)
+  (test covered? => #f))
+
+(define (test-phase-1-coverage)
+  (define test-coverage-enabled? #t)
+
+  (define test-coverage-at-compile-time (lambda () #t))
+
+
+  (define covered? #f)
+  (define initialized? #f)
+
+  (define (test-coverage-point body expr phase)
+    (cond [(eq? (syntax-e expr) 'x)
+           (set! initialized? #t)
+           #`(begin (#%plain-app #,(lambda () (set! covered? #t)))
+                    #,body)]
+          [else body]))
+
+  (define-values/invoke-unit/infer stacktrace/annotator@)
+
+  (define test-stx
+    #'(module test racket (begin-for-syntax (define x 5) x)))
+  (define ns (make-base-namespace))
+  (parameterize ([current-namespace ns])
+    (eval (expand (annotate-top (expand test-stx) 0)))
+    (eval '(require 'test)))
+  (test initialized? => #t)
+  (test covered? => #t))

--- a/errortrace-test/tests/errortrace/wrap.rkt
+++ b/errortrace-test/tests/errortrace/wrap.rkt
@@ -1,7 +1,5 @@
 #lang racket/base
 
-(require tests/eli-tester)
-
 (define err-stx #'(error '"bad"))
 
 (define (try expr)

--- a/errortrace-test/tests/errortrace/wrap.rkt
+++ b/errortrace-test/tests/errortrace/wrap.rkt
@@ -1,5 +1,7 @@
 #lang racket/base
 
+(require tests/eli-tester)
+
 (define err-stx #'(error '"bad"))
 
 (define (try expr)

--- a/errortrace/info.rkt
+++ b/errortrace/info.rkt
@@ -9,6 +9,6 @@
 
 (define pkg-desc "Instrumentation tools for debugging")
 
-(define pkg-authors '(mflatt))
+(define pkg-authors '(mflatt "spencer@florence.io"))
 
 (define version "1.1")

--- a/errortrace/info.rkt
+++ b/errortrace/info.rkt
@@ -10,3 +10,5 @@
 (define pkg-desc "Instrumentation tools for debugging")
 
 (define pkg-authors '(mflatt))
+
+(define version "1.1")


### PR DESCRIPTION
This commit extents the units provided by `errortrace/stacktrace` to allow a user to get test coverage at phases above phase 0. (This going to be used by cover: https://github.com/florence/cover/tree/phase-1%2B-coverage )