### PR TITLE
fix identifier coverage for define-syntax

### DIFF
--- a/errortrace-lib/errortrace/stacktrace.rkt
+++ b/errortrace-lib/errortrace/stacktrace.rkt
@@ -308,14 +308,18 @@
                                      (syntax-case vars () [(id) (syntax id)] [_else #f])
                                      rhs
                                      phase))
-                       (for/fold ([rhs rhs*]) ([name (in-list (syntax->list vars))])
-                         (test-coverage-point rhs name phase)))
+                       (cover-names vars rhs* phase))
                      varss
                      rhss)]
               [bodyl (map (lambda (body) (no-cache-annotate body phase))
                           bodys)])
           (rebuild expr (append (map cons bodys bodyl)
                                 (map cons rhss rhsl)))))))
+
+
+  (define (cover-names names-stx body phase)
+    (for/fold ([body body]) ([name (in-list (syntax->list names-stx))])
+      (test-coverage-point body name phase)))
 
   (define ((simple-rhs? phase) expr)
     (kernel-syntax-case/phase expr phase
@@ -436,18 +440,7 @@
                               (one-name #'names)
                               (syntax rhs)
                               phase))]
-                 [with-coverage
-                  (let loop ([stx #'names]
-                             [obj marked])
-                    (cond
-                     [(not (syntax? stx)) obj]
-                     [(identifier? stx)
-                      (test-coverage-point obj stx phase)]
-                     [(pair? (syntax-e stx))
-                      (loop (car (syntax-e stx))
-                            (loop (cdr (syntax-e stx))
-                                  obj))]
-                     [else obj]))])
+                 [with-coverage (cover-names #'names marked phase)])
             (rearm
              expr
              (rebuild 
@@ -462,15 +455,17 @@
                          no-cache-annotate-top phase))]
          [(define-syntaxes (name ...) rhs)
           top?
-          (let ([marked (with-mark expr
-                                   (no-cache-annotate-named
-                                    (one-name #'(name ...))
-                                    (syntax rhs)
-                                    (add1 phase))
-                                   (add1 phase))])
+          (let* ([marked (with-mark expr
+                           (no-cache-annotate-named
+                            (one-name #'(name ...))
+                            (syntax rhs)
+                            (add1 phase))
+                           (add1 phase))]
+                 ;; cover at THIS phase, since thats where its bound
+                 [with-coverage (cover-names #'(name ...) marked phase)])
             (rearm
              expr
-             (rebuild disarmed-expr (list (cons #'rhs marked)))))]
+             (rebuild disarmed-expr (list (cons #'rhs with-coverage)))))]
          
          [(begin-for-syntax . exprs)
           top?

--- a/errortrace-test/tests/errortrace/coverage-define-syntax.rkt
+++ b/errortrace-test/tests/errortrace/coverage-define-syntax.rkt
@@ -1,0 +1,45 @@
+#lang racket/base
+
+(provide define-syntax-test)
+(require errortrace/stacktrace racket/unit tests/eli-tester)
+
+
+(define (with-mark src dest phase) dest)
+(define test-coverage-enabled (make-parameter #t))
+(define profile-key (gensym))
+(define profiling-enabled (make-parameter #f))
+(define initialize-profile-point void)
+(define (register-profile-start . a) #f)
+(define register-profile-done void)
+(define test-coverage-enabled? #t)
+
+(define covered? #f)
+(define initialized? #f)
+(define (test-covered stx)
+  (if (eq? (syntax-e stx) '++)
+      (lambda () (set! covered? #t))
+      void))
+(define (initialize-test-coverage-point stx)
+  (when (eq? (syntax-e stx) '++)
+    (set! initialized? #t)))
+(define-values/invoke-unit/infer stacktrace@)
+
+(define (define-syntax-test)
+  (define test-stx
+    #'(module test racket
+        (require (for-syntax syntax/parse))
+        (define-syntax (define/broken-provide stx)
+          (syntax-parse stx
+            [(_ x:id y)
+             #'(begin
+                 (define-syntax x (make-rename-transformer #'y))
+                 (provide x)
+                 (define (k) x))]))
+
+        (define/broken-provide ++ +)))
+  (define ns (make-base-namespace))
+  (parameterize ([current-namespace ns])
+    (eval (annotate-top (expand test-stx) 0))
+    (eval '(require 'test)))
+  (test initialized? => #t)
+  (test covered? => #t))

--- a/errortrace-test/tests/errortrace/main.rkt
+++ b/errortrace-test/tests/errortrace/main.rkt
@@ -7,6 +7,7 @@
          "phase-1-eval.rkt"
          "begin.rkt"
          "coverage-let.rkt"
+         "coverage-define-syntax.rkt"
          "test-compile-time.rkt")
 
 (wrap-tests)
@@ -14,6 +15,7 @@
 (test do (alert-tests))
 (test do (letrec-test))
 (test do (test-phase-coverage))
+(test do (define-syntax-test))
 
 (phase-1-tests)
 (phase-1-eval-tests)


### PR DESCRIPTION
Fixes covering identifiers for define-syntax.

This caused the issue noted in florence/cover/issues/121