### PR TITLE
use `lang-reader-module-paths` instead of copy-pasted code

### DIFF
--- a/errortrace-lib/errortrace/lang/reader.rkt
+++ b/errortrace-lib/errortrace/lang/reader.rkt
@@ -20,15 +20,7 @@
     (make-meta-reader
      'errortrace
      "language path"
-     (lambda (bstr)
-       (let* ([str (bytes->string/latin-1 bstr)]
-              [sym (string->symbol str)])
-         (and (module-path? sym)
-              (vector
-               ;; try submod first:
-               `(submod ,sym reader)
-               ;; fall back to /lang/reader:
-               (string->symbol (string-append str "/lang/reader"))))))
+     lang-reader-module-paths
      wrap-reader
      wrap-reader
      values)))

--- a/errortrace-lib/info.rkt
+++ b/errortrace-lib/info.rkt
@@ -1,6 +1,6 @@
 #lang info
 (define collection 'multi)
-(define deps '("base" "source-syntax"))
+(define deps '(["base" #:version "6.6.0.3"] "source-syntax"))
 
 (define pkg-desc "implementation (no documentation) part of \"errortrace\"")
 


### PR DESCRIPTION
Relies on https://github.com/racket/racket/commit/42dcc525b1e03ca36488b815b45428655fdcbf1b

This replaces the 9-line copy-pasted 3rd argument to `make-meta-reader` with `lang-reader-module-paths`, which gets the possible module-paths to the reader module of the base language.