### PR TITLE
fix for define-syntax

### DIFF
--- a/errortrace-lib/errortrace/stacktrace.rkt
+++ b/errortrace-lib/errortrace/stacktrace.rkt
@@ -462,10 +462,9 @@
                             (add1 phase))
                            (add1 phase))]
                  ;; cover at THIS phase, since thats where its bound
-                 [with-coverage (cover-names #'(name ...) marked phase)])
-            (rearm
-             expr
-             (rebuild disarmed-expr (list (cons #'rhs with-coverage)))))]
+                 [rebuilt (rebuild disarmed-expr (list (cons #'rhs marked)))]
+                 [with-coverage (cover-names #'(name ...) rebuilt phase)])
+            (rearm expr with-coverage))]
          
          [(begin-for-syntax . exprs)
           top?

--- a/errortrace-test/tests/errortrace/define-syntaxes-id-test.rkt
+++ b/errortrace-test/tests/errortrace/define-syntaxes-id-test.rkt
@@ -1,0 +1,37 @@
+#lang racket/base
+(provide test-define-syntaxes-coverage)
+(require errortrace/stacktrace racket/unit tests/eli-tester)
+
+(define (with-mark src dest phase) dest)
+(define test-coverage-enabled (make-parameter #t))
+(define profile-key (gensym))
+(define profiling-enabled (make-parameter #f))
+(define initialize-profile-point void)
+(define (register-profile-start . a) #f)
+(define register-profile-done void)
+
+(define (test-define-syntaxes-coverage)
+  (define covered? (mcons #f #f))
+  (define initialized? #f)
+
+  (define ns (make-base-namespace))
+  (parameterize ([current-namespace ns])
+
+    (define test-coverage-enabled? #t)
+    (define (test-covered stx)
+      (if (eq? (syntax-e stx) 'x)
+          #`(#%plain-app set-mcar! #,covered? #t)
+          void))
+
+    (define (initialize-test-coverage-point stx)
+      (when (eq? (syntax-e stx) 'x)
+        (set! initialized? #t)))
+    (define test-stx
+      #'(module test racket/base
+          (define-syntax-rule (x) 0)))
+
+    (define-values/invoke-unit/infer stacktrace@)
+    (eval (annotate-top (namespace-syntax-introduce (expand test-stx)) 0))
+    (eval '(require 'test))
+    (test initialized? => #t)
+    (test (mcar covered?) => #t)))

--- a/errortrace-test/tests/errortrace/main.rkt
+++ b/errortrace-test/tests/errortrace/main.rkt
@@ -1,13 +1,14 @@
 #lang racket/base
 
-(require tests/eli-tester 
-         "wrap.rkt" 
+(require tests/eli-tester
+         "wrap.rkt"
          "alert.rkt"
          "phase-1.rkt"
          "phase-1-eval.rkt"
          "begin.rkt"
          "coverage-let.rkt"
          "coverage-define-syntax.rkt"
+         "define-syntaxes-id-test.rkt"
          "test-compile-time.rkt")
 
 (wrap-tests)
@@ -16,6 +17,7 @@
 (test do (letrec-test))
 (test do (test-phase-coverage))
 (test do (define-syntax-test))
+(test do (test-define-syntaxes-coverage))
 
 (phase-1-tests)
 (phase-1-eval-tests)


### PR DESCRIPTION
Fix for https://github.com/racket/errortrace/commit/af41340725d905888b5cb939e0d88acd9972101a#commitcomment-18823690

I'm having difficulty working out a test that doesn't use `racket/sandbox`'s test coverage.