### PR TITLE
Errortrace change to reduce overhead on `for`, etc.

### DIFF
--- a/errortrace-doc/errortrace/scribblings/errortrace.scrbl
+++ b/errortrace-doc/errortrace/scribblings/errortrace.scrbl
@@ -366,8 +366,8 @@ Errortrace run-time support.}
 @defmodule[errortrace/stacktrace]{
 The errortrace collection also includes a
 @racketmodname[errortrace/stacktrace] library. It exports
-the @racket[stacktrace@] unit, its import signature
-@racket[stacktrace-imports^], and its export signature
+the @racket[stacktrace@] unit (plus a few generalized variants), its import signature
+@racket[stacktrace-imports^] (plus signatures for genealizations), and its export signature
 @racket[stacktrace^].}
 
 @defthing[stacktrace@ unit?]{
@@ -378,6 +378,20 @@ Imports @racket[stacktrace-imports^] and exports @racket[stacktrace^].}
 @defthing[stacktrace/annotator@ unit?]{
 
 Imports @racket[stacktrace/annotator-imports^] and exports @racket[stacktrace^].}
+
+
+@defthing[stacktrace/filter@ unit?]{
+
+Imports @racket[stacktrace-imports^] and @racket[stacktrace-filter^] and exports @racket[stacktrace^].
+
+@history[#:added "1.2"]}
+
+
+@defthing[stacktrace/annotator/filter@ unit?]{
+
+Imports @racket[stacktrace/annotator-imports^] and @racket[stacktrace-filter^] and exports @racket[stacktrace^].
+
+@history[#:added "1.2"]}
 
 
 @defsignature[stacktrace^ ()]{
@@ -550,6 +564,30 @@ Same as in @racket[stacktrace-imports^].}
 Same as @racket[stacktrace-imports^].}
 
 }
+
+
+@defsignature[stacktrace-filter^ ()]{
+
+The function defined for @racket[stacktrace-filter^] provides additional
+control over the expressions that are instrumented for debugging an
+profiling.
+
+@history[#:added "1.2"]
+
+@defproc[(should-annotate? [stx syntax?] [phase exact-nonnegative-integer?]) any/c]{
+
+Determines whether the @racketout[annotate] function from
+@racket[stacktrace/filter@] or @racket[stacktrace/annotator/filter@]
+adds debugging and/or test-coverage annotation to the immediate expression represented
+by @racket[stx]. Annotation is added only when
+@sigelem[stacktrace-filter^ should-annotate?] returns a true value, but
+subexpressions of @racket[stx] will be checked and potentially annotated
+independent of the result for @racket[stx].
+
+The default filter function used by @racket[stacktrace@] and
+@racket[stacktrace/annotator@] annotates an expression if it has a
+source location according to @racket[syntax-source].}}
+
 
 @section{Errortrace Key}
 @defmodule[errortrace/errortrace-key]

--- a/errortrace-lib/errortrace/errortrace-lib.rkt
+++ b/errortrace-lib/errortrace/errortrace-lib.rkt
@@ -263,7 +263,60 @@
                  expr))))
         expr)))
 
-(define-values/invoke-unit/infer stacktrace@)
+(define (should-annotate? s phase)
+  (and (syntax-source s)
+       (syntax-property s 'errortrace:annotate)))
+
+;; Add the 'errortrace:annotate property every in an original syntax
+;; object, so that we can recognize pieces from the original program
+;; after expansion:
+(define (add-annotate-property s)
+  (cond
+   [(syntax? s)
+    (define new-s (syntax-rearm 
+                   (let ([s (disarm s)])
+                     (datum->syntax s
+                                    (add-annotate-property (syntax-e s))
+                                    s
+                                    s))
+                   s))
+    ;; We could check for "original" syntax here, because partial expansion
+    ;; of top-level forms happens before the compile handler gets
+    ;; control. As a compromise for programs that may use errortrace
+    ;; with `eval` and S-expressions or non-`syntax-original?` arrangements, we add
+    ;; the property everywhere:
+    (if #t ; (syntax-original? s)
+        (syntax-property new-s
+                         'errortrace:annotate #t
+                         ;; preserve the property in bytecode:
+                         #t)
+        new-s)]
+   [(pair? s)
+    (cons (add-annotate-property (car s))
+          (add-annotate-property (cdr s)))]
+   [(vector? s)
+    (for/vector #:length (vector-length s) ([e (in-vector s)])
+                (add-annotate-property s))]
+   [(box? s) (box (add-annotate-property (unbox s)))]
+   [(prefab-struct-key s)
+    => (lambda (k)
+         (apply make-prefab-struct
+                k
+                (add-annotate-property (cdr (vector->list (struct->vector s))))))]
+   [(and (hash? s) (immutable? s))
+    (cond
+     [(hash-eq? s)
+      (for/hasheq ([(k v) (in-hash s)])
+        (values k (add-annotate-property s)))]
+     [(hash-eqv? s)
+      (for/hasheqv ([(k v) (in-hash s)])
+        (values k (add-annotate-property s)))]
+     [else
+      (for/hash ([(k v) (in-hash s)])
+        (values k (add-annotate-property s)))])]
+   [else s]))
+
+(define-values/invoke-unit/infer stacktrace/filter@)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Execute counts
@@ -443,7 +496,7 @@
 (define errortrace-annotate
   (lambda (top-e)
     (define (normal e)
-      (define expanded-e (expand-syntax e))
+      (define expanded-e (expand-syntax (add-annotate-property e)))
       (parameterize ([original-stx e]
                      [expanded-stx expanded-e])
         (annotate-top expanded-e (namespace-base-phase))))

--- a/errortrace-lib/info.rkt
+++ b/errortrace-lib/info.rkt
@@ -6,4 +6,4 @@
 
 (define pkg-authors '(mflatt robby florence))
 
-(define version "1.1")
+(define version "1.2")

--- a/errortrace-test/tests/errortrace/wrap.rkt
+++ b/errortrace-test/tests/errortrace/wrap.rkt
@@ -1,6 +1,9 @@
-#lang racket/base
+#lang at-exp racket/base
 
-(define err-stx #'(error '"bad"))
+(define err-stx
+  ;; Using `read-syntax` ensures that it's syntax-original:
+  (read-syntax 'source
+               @open-input-string{(error '"bad")}))
 
 (define (try expr)
   (define out-str


### PR DESCRIPTION
Finally following up on

  https://groups.google.com/d/msg/racket-dev/_bdbMn2PmC4/18XufAkWBgAJ

which continued from

  https://groups.google.com/d/msg/racket-users/WvThwc98kMU/eebYvMbMAwAJ