### PR TITLE
Should fix #14. Generate #%require at namespace base phase for top-level expressions

### DIFF
--- a/errortrace-lib/errortrace/private/utils.rkt
+++ b/errortrace-lib/errortrace/private/utils.rkt
@@ -1,7 +1,8 @@
 #lang racket/base
 
 (provide count-meta-levels
-         generate-key-imports)
+         generate-key-imports
+         generate-key-imports-at-phase)
 
 (define base (variable-reference->module-base-phase (#%variable-reference)))
 
@@ -19,7 +20,11 @@
     [_ 0]))
 
 
+;; generate imports for errortrace/errortrace-key at (syntax-local-phase-level)
 (define (generate-key-imports meta-depth)
+  (generate-key-imports-at-phase meta-depth (syntax-local-phase-level)))
+
+(define (generate-key-imports-at-phase meta-depth phase)
   (syntax-shift-phase-level
    (let loop ([meta-depth meta-depth])
      (let ([e ((make-syntax-introducer)
@@ -28,4 +33,4 @@
        (if (zero? meta-depth)
            e
            #`(begin #,e #,(loop (sub1 meta-depth))))))
-   (- (syntax-local-phase-level) base)))
+   (- phase base)))

--- a/errortrace-lib/errortrace/stacktrace.rkt
+++ b/errortrace-lib/errortrace/stacktrace.rkt
@@ -735,7 +735,7 @@
            (for ([i (in-range meta-depth)])
              (namespace-require `(for-meta ,(add1 i) errortrace/errortrace-key))))
          #`(begin
-             #,(generate-key-imports meta-depth)
+             #,(generate-key-imports-at-phase meta-depth (namespace-base-phase))
              #,e))]))
 
   (define (has-cross-phase-declare? e)

--- a/errortrace-test/tests/errortrace/main.rkt
+++ b/errortrace-test/tests/errortrace/main.rkt
@@ -3,6 +3,7 @@
 (require tests/eli-tester
          "wrap.rkt"
          "alert.rkt"
+         "phase-0-eval.rkt"
          "phase-1.rkt"
          "phase-1-eval.rkt"
          "phase-1-module.rkt"
@@ -30,3 +31,4 @@
 (begin-for-syntax-tests)
 (profile-tests)
 (cross-phase-tests)
+(phase-0-eval-tests)

--- a/errortrace-test/tests/errortrace/phase-0-eval.rkt
+++ b/errortrace-test/tests/errortrace/phase-0-eval.rkt
@@ -1,0 +1,33 @@
+#lang racket/base
+
+(provide phase-0-eval-tests)
+
+;; A Test case from @florence in issue #14
+;;
+;; When phase-1-eval is required for-template, the evaluation takes place at phase 0,
+;; so errortrace will generate top-level #%requires after annotating '(+ 1 2).
+;;
+;; we need to use namespace-base-phase (which is 0) for these top-level #%requires
+;; instead of syntax-local-phase-level (which is -1), which should be used for #%requires
+;; inside phase-1-eval.
+(define (phase-0-eval-tests)
+  ;; In 'phase-1-eval, we are evaling in the namespace of racket/base.
+  ;; Therefore we re-load racket/base in a fresh empty namespace
+  ;; to avoid affecting other programs.
+  (define source-namespace (current-namespace))
+  (parameterize ([current-namespace (make-empty-namespace)])
+    (namespace-attach-module source-namespace ''#%builtin)
+    (namespace-require 'racket/base)
+
+    (dynamic-require 'errortrace #f)
+
+    (eval '(module phase-1-eval racket/base
+             (require (for-syntax racket/base))
+             (begin-for-syntax
+               (parameterize ([current-namespace (module->namespace 'racket/base)])
+                 (eval '(+ 1 2))))))
+
+    (eval '(module template racket/base
+             (require (for-template 'phase-1-eval))))
+
+    (dynamic-require ''template #f)))


### PR DESCRIPTION
After this patch, the test case posted by @florence in #14 passes. The following program also runs, but I didn't run it in DrRacket.

```
#lang racket
(require errortrace)
(require (for-template phc-adt))
```