### PR TITLE
Identify top-level modules inside begin-for-syntax and insert requires.

### DIFF
--- a/errortrace-lib/errortrace/errortrace-lib.rkt
+++ b/errortrace-lib/errortrace/errortrace-lib.rkt
@@ -542,7 +542,7 @@
            (for ([i (in-range meta-depth)])
              (namespace-require `(for-meta ,(add1 i) errortrace/errortrace-key)))
            #`(begin
-               #,(generate-key-imports meta-depth)
+               #,(generate-key-imports-at-phase meta-depth (namespace-base-phase))
                #,e)))])))
 
 (define (has-cross-phase-declare? e)

--- a/errortrace-lib/errortrace/private/utils.rkt
+++ b/errortrace-lib/errortrace/private/utils.rkt
@@ -1,7 +1,8 @@
 #lang racket/base
 
 (provide count-meta-levels
-         generate-key-imports)
+         generate-key-imports
+         generate-key-imports-at-phase)
 
 (define base (variable-reference->module-base-phase (#%variable-reference)))
 
@@ -19,7 +20,11 @@
     [_ 0]))
 
 
+;; generate imports for errortrace/errortrace-key at (syntax-local-phase-level)
 (define (generate-key-imports meta-depth)
+  (generate-key-imports-at-phase meta-depth (syntax-local-phase-level)))
+
+(define (generate-key-imports-at-phase meta-depth phase)
   (syntax-shift-phase-level
    (let loop ([meta-depth meta-depth])
      (let ([e ((make-syntax-introducer)
@@ -28,4 +33,4 @@
        (if (zero? meta-depth)
            e
            #`(begin #,e #,(loop (sub1 meta-depth))))))
-   (- (syntax-local-phase-level) base)))
+   (- phase base)))

--- a/errortrace-test/tests/errortrace/main.rkt
+++ b/errortrace-test/tests/errortrace/main.rkt
@@ -3,6 +3,7 @@
 (require tests/eli-tester
          "wrap.rkt"
          "alert.rkt"
+         "phase-0-eval.rkt"
          "phase-1.rkt"
          "phase-1-eval.rkt"
          "phase-2-profile.rkt"
@@ -28,3 +29,4 @@
 (begin-for-syntax-tests)
 (profile-tests)
 (cross-phase-tests)
+(phase-0-eval-tests)

--- a/errortrace-test/tests/errortrace/main.rkt
+++ b/errortrace-test/tests/errortrace/main.rkt
@@ -6,6 +6,7 @@
          "phase-0-eval.rkt"
          "phase-1.rkt"
          "phase-1-eval.rkt"
+         "phase-1-top-module.rkt"
          "phase-2-profile.rkt"
          "begin.rkt"
          "coverage-let.rkt"
@@ -30,3 +31,4 @@
 (profile-tests)
 (cross-phase-tests)
 (phase-0-eval-tests)
+(phase-1-top-module-tests)

--- a/errortrace-test/tests/errortrace/phase-0-eval.rkt
+++ b/errortrace-test/tests/errortrace/phase-0-eval.rkt
@@ -1,0 +1,33 @@
+#lang racket/base
+
+(provide phase-0-eval-tests)
+
+;; A Test case from @florence in issue #14
+;;
+;; When phase-1-eval is required for-template, the evaluation takes place at phase 0,
+;; so errortrace will generate top-level #%requires after annotating '(+ 1 2).
+;;
+;; we need to use namespace-base-phase (which is 0) for these top-level #%requires
+;; instead of syntax-local-phase-level (which is -1), which should be used for #%requires
+;; inside phase-1-eval.
+(define (phase-0-eval-tests)
+  ;; In 'phase-1-eval, we are evaling in the namespace of racket/base.
+  ;; Therefore we re-load racket/base in a fresh empty namespace
+  ;; to avoid affecting other programs.
+  (define source-namespace (current-namespace))
+  (parameterize ([current-namespace (make-empty-namespace)])
+    (namespace-attach-module source-namespace ''#%builtin)
+    (namespace-require 'racket/base)
+
+    (dynamic-require 'errortrace #f)
+
+    (eval '(module phase-1-eval racket/base
+             (require (for-syntax racket/base))
+             (begin-for-syntax
+               (parameterize ([current-namespace (module->namespace 'racket/base)])
+                 (eval '(+ 1 2))))))
+
+    (eval '(module template racket/base
+             (require (for-template 'phase-1-eval))))
+
+    (dynamic-require ''template #f)))

--- a/errortrace-test/tests/errortrace/phase-1-top-module.rkt
+++ b/errortrace-test/tests/errortrace/phase-1-top-module.rkt
@@ -1,0 +1,18 @@
+#lang racket/base
+
+(provide phase-1-top-module-tests)
+
+;; Simplified program reported in issue #8.
+;;
+;; Declare a top-level module inside begin-for-syntax
+;; then instantiate it at phase 0.
+;;
+;; This should work as if the module was decalre outside
+;; begin-for-syntax except the `module` identifier needs
+;; to be bound at phase 1.
+(define (phase-1-top-module-tests)
+  (parameterize ([current-namespace (make-base-namespace)])
+    (dynamic-require 'errortrace #f)
+    (eval '(require (for-syntax racket/base)))
+    (eval '(begin-for-syntax (module m racket/base)))
+    (dynamic-require ''m #f)))


### PR DESCRIPTION
In issue #8, the require `(#%require (for-meta 0 errortrace/errortrace-key))` is not inserted by the annotator since the entire `(begin-for-syntax ...)` form falls into the `_else` branch in the function `errortrace-annotate`. As a result, the syntax object `#'errortrace-key` introduced by `with-mark` causes the expander to try to bring in wrong modules. This pull request makes `errortrace-annotate` traverse top-level `begin` forms and `begin-for-syntax` forms to identify all top-level modules.

p.s. I don't have push access, but I think it's better to merge these two pull requests after branching day.