### PR TITLE
Fix cross-phase persistent module instrumentation

### DIFF
--- a/errortrace-doc/errortrace/scribblings/errortrace.scrbl
+++ b/errortrace-doc/errortrace/scribblings/errortrace.scrbl
@@ -456,10 +456,12 @@ hardwired to return @racket[null]. }
  @defproc[(errortrace-annotate [stx syntax?]
                                [in-compile-handler? boolean? #t])
           syntax?]{
+  Adds the property @racket['errortrace:annotate] to everywhere inside
+  @racket[stx], and expands it.
   If @racket[stx] is a module (but not named @racketidfont{errortrace-key}
-  module nor a @tech[#:doc '(lib "scribblings/reference/reference.scrbl")]{cross-phase persistent} module), adds the property @racket['errortrace:annotate] to everywhere inside
-  @racket[stx], expands it and then calls @racketout[annotate-top] with the result.
-  Also inserts appropriate requires to the @racketidfont{errortrace-key} module.
+  module nor a @tech[#:doc '(lib "scribblings/reference/reference.scrbl")]{cross-phase persistent} module),
+  calls @racketout[annotate-top] with the expanded code and inserts appropriate requires
+  to the @racketidfont{errortrace-key} module.
 
   If @racket[in-compile-handler?] is true, also calls @racket[namespace-require]
   to load @racketidfont{errortrace-key}.

--- a/errortrace-doc/errortrace/scribblings/errortrace.scrbl
+++ b/errortrace-doc/errortrace/scribblings/errortrace.scrbl
@@ -456,11 +456,10 @@ hardwired to return @racket[null]. }
  @defproc[(errortrace-annotate [stx syntax?]
                                [in-compile-handler? boolean? #t])
           syntax?]{
-  Adds the property @racket['errortrace:annotate] to everywhere inside
-  @racket[stx], expands it and then calls @racketout[annotate-top] with the result.
   If @racket[stx] is a module (but not named @racketidfont{errortrace-key}
-  module nor a @tech[#:doc '(lib "scribblings/reference/reference.scrbl")]{cross-phase persistent} module),
-  inserts appropriate requires to the @racketidfont{errortrace-key} module.
+  module nor a @tech[#:doc '(lib "scribblings/reference/reference.scrbl")]{cross-phase persistent} module), adds the property @racket['errortrace:annotate] to everywhere inside
+  @racket[stx], expands it and then calls @racketout[annotate-top] with the result.
+  Also inserts appropriate requires to the @racketidfont{errortrace-key} module.
 
   If @racket[in-compile-handler?] is true, also calls @racket[namespace-require]
   to load @racketidfont{errortrace-key}.

--- a/errortrace-lib/errortrace/stacktrace.rkt
+++ b/errortrace-lib/errortrace/stacktrace.rkt
@@ -741,7 +741,7 @@
   (define (has-cross-phase-declare? e)
     (for/or ([a (in-list (or (syntax->list e) '()))])
       (syntax-case* a (#%declare begin) (lambda (a b)
-                                          (free-identifier=? a b 0 (namespace-base-phase)))
+                                          (free-identifier=? a b 0 base-phase))
         [(#%declare kw ...)
          (for/or ([kw (in-list (syntax->list #'(kw ...)))])
            (eq? (syntax-e kw) '#:cross-phase-persistent))]

--- a/errortrace-lib/errortrace/stacktrace.rkt
+++ b/errortrace-lib/errortrace/stacktrace.rkt
@@ -692,7 +692,7 @@
       (define expanded-e (expand-syntax (add-annotate-property e)))
       (parameterize ([original-stx e]
                      [expanded-stx expanded-e])
-        (annotate-top expanded-e (namespace-base-phase))))
+        (values expanded-e (annotate-top expanded-e (namespace-base-phase)))))
     (syntax-case top-e ()
       [(mod name . reste)
        (and (identifier? #'mod)
@@ -701,12 +701,12 @@
                                (namespace-base-phase)))
        (if (eq? (syntax-e #'name) 'errortrace-key)
            top-e
-           (let ([expanded-e (normal top-e)])
+           (let-values ([(unannotated-e expanded-e) (normal top-e)])
              (cond
                [(has-cross-phase-declare?
                  (syntax-case expanded-e ()
                    [(mod name init-import mb) #'mb]))
-                expanded-e]
+                unannotated-e]
                [else
                 (transform-all-modules
                  expanded-e
@@ -726,7 +726,7 @@
                                            #'mb))))])])))])))]
       [_else
        (let ()
-         (define e (normal top-e))
+         (define-values (_unannotated-e e) (normal top-e))
          (define meta-depth ((count-meta-levels 0) e))
          (when in-compile-handler?
            ;; We need to force the `require`s now, so that `e` can be compiled.

--- a/errortrace-test/tests/errortrace/cross-phase-mod.rkt
+++ b/errortrace-test/tests/errortrace/cross-phase-mod.rkt
@@ -1,0 +1,2 @@
+(module cross-phase '#%kernel
+  (#%declare #:cross-phase-persistent))

--- a/errortrace-test/tests/errortrace/cross-phase.rkt
+++ b/errortrace-test/tests/errortrace/cross-phase.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 
-(provide cross-phase-tests)
+(provide cross-phase-tests
+         cross-phase-2-tests)
 
 ;; Check that errortrace is ok with `(#%declare #:cross-phase-persistent)`
 (define (cross-phase-tests)
@@ -8,5 +9,12 @@
   (parameterize ([current-namespace ns])
     (dynamic-require 'errortrace #f)
     (eval '(module cross-phase '#%kernel
-            (define-values (a) 1)
             (#%declare #:cross-phase-persistent)))))
+
+(define (cross-phase-2-tests)
+  (define ns (make-base-namespace))
+  (parameterize ([current-namespace ns])
+    (dynamic-require 'errortrace #f)
+    (eval '(module cross-phase '#%kernel
+             (define-values (a) 1)
+             (#%declare #:cross-phase-persistent)))))

--- a/errortrace-test/tests/errortrace/cross-phase.rkt
+++ b/errortrace-test/tests/errortrace/cross-phase.rkt
@@ -8,4 +8,5 @@
   (parameterize ([current-namespace ns])
     (dynamic-require 'errortrace #f)
     (eval '(module cross-phase '#%kernel
+            (define-values (a) 1)
             (#%declare #:cross-phase-persistent)))))

--- a/errortrace-test/tests/errortrace/cross-phase.rkt
+++ b/errortrace-test/tests/errortrace/cross-phase.rkt
@@ -1,20 +1,30 @@
 #lang racket/base
 
-(provide cross-phase-tests
-         cross-phase-2-tests)
+(provide cross-phase-tests)
 
-;; Check that errortrace is ok with `(#%declare #:cross-phase-persistent)`
 (define (cross-phase-tests)
-  (define ns (make-base-namespace))
-  (parameterize ([current-namespace ns])
-    (dynamic-require 'errortrace #f)
-    (eval '(module cross-phase '#%kernel
-            (#%declare #:cross-phase-persistent)))))
-
-(define (cross-phase-2-tests)
-  (define ns (make-base-namespace))
-  (parameterize ([current-namespace ns])
-    (dynamic-require 'errortrace #f)
-    (eval '(module cross-phase '#%kernel
-             (define-values (a) 1)
-             (#%declare #:cross-phase-persistent)))))
+  ;; Check that errortrace is ok with `(#%declare #:cross-phase-persistent)`
+  (let ()
+    (define ns (make-base-namespace))
+    (parameterize ([current-namespace ns])
+      (dynamic-require 'errortrace #f)
+      (eval '(module cross-phase '#%kernel
+               (#%declare #:cross-phase-persistent)))))
+  ;; Check that errortrace doesn't instrument cross phase persistent modules
+  (let ()
+    (define ns (make-base-namespace))
+    (parameterize ([current-namespace ns])
+      (dynamic-require 'errortrace #f)
+      (eval '(module cross-phase '#%kernel
+               (define-values (a) 1)
+               (#%declare #:cross-phase-persistent)))))
+  ;; Check that errortrace uses free-identifier=? correctly
+  (let ()
+    (define ns (make-base-namespace))
+    (parameterize ([current-namespace ns])
+      (dynamic-require 'errortrace #f)
+      (eval '(module a racket
+               (dynamic-require-for-syntax "cross-phase-mod.rkt" #f)))
+      (eval '(module b racket
+               (dynamic-require-for-syntax ''a #f)))
+      (eval '(require 'b)))))

--- a/errortrace-test/tests/errortrace/main.rkt
+++ b/errortrace-test/tests/errortrace/main.rkt
@@ -30,3 +30,4 @@
 (begin-for-syntax-tests)
 (profile-tests)
 (cross-phase-tests)
+(cross-phase-2-tests)

--- a/errortrace-test/tests/errortrace/main.rkt
+++ b/errortrace-test/tests/errortrace/main.rkt
@@ -30,4 +30,3 @@
 (begin-for-syntax-tests)
 (profile-tests)
 (cross-phase-tests)
-(cross-phase-2-tests)


### PR DESCRIPTION
Currently, running `racket -l errortrace -t a.rkt`
where `a.rkt` is:

```
(module a '#%kernel
  (define-values (a) 1)
  (#%declare #:cross-phase-persistent))
```

causes an error that errortrace-key could not be found.
As cross-phase persistent module could not require
errortrace-key, we need to skip instrumenting
the module entirely.

EDIT: This PR also fixes #24 