### PR TITLE
traverse hashalw

### DIFF
--- a/errortrace-lib/errortrace/stacktrace.rkt
+++ b/errortrace-lib/errortrace/stacktrace.rkt
@@ -797,6 +797,9 @@
          [(hash-eqv? s)
           (for/hasheqv ([(k v) (in-hash s)])
             (values k (add-annotate-property v)))]
+         [(hash-equal-always? s)
+          (for/hashalw ([(k v) (in-hash s)])
+            (values k (add-annotate-property v)))]
          [else
           (for/hash ([(k v) (in-hash s)])
             (values k (add-annotate-property v)))])]

--- a/errortrace-test/tests/errortrace/simple.rkt
+++ b/errortrace-test/tests/errortrace/simple.rkt
@@ -108,3 +108,5 @@
        '#hasheq((a . 0)))
 (check '#hasheqv((a . 0))
        '#hasheqv((a . 0)))
+(check '#hashalw((a . 0))
+       '#hashalw((a . 0)))


### PR DESCRIPTION
Goes along with https://github.com/racket/racket/pull/4236 which adds `equal-always?` and `hashalw` along with it.