### PR TITLE
use hash-map/copy

### DIFF
--- a/errortrace-lib/errortrace/stacktrace.rkt
+++ b/errortrace-lib/errortrace/stacktrace.rkt
@@ -790,16 +790,9 @@
                    k
                    (add-annotate-property (cdr (vector->list (struct->vector s))))))]
       [(and (hash? s) (immutable? s))
-       (cond
-         [(hash-eq? s)
-          (for/hasheq ([(k v) (in-hash s)])
-            (values k (add-annotate-property v)))]
-         [(hash-eqv? s)
-          (for/hasheqv ([(k v) (in-hash s)])
-            (values k (add-annotate-property v)))]
-         [else
-          (for/hash ([(k v) (in-hash s)])
-            (values k (add-annotate-property v)))])]
+       (hash-map/copy s
+                      (lambda (k v)
+                        (values k (add-annotate-property v))))]
       [else s]))
 
   (define (transform-all-modules stx proc [in-mod-id (namespace-module-identifier)])


### PR DESCRIPTION
Instead of enumerating variants of hash tables.

Replaces https://github.com/racket/errortrace/pull/28 so that it doesn't have to add `hashalw` to any enumeration of variants here.