### PR TITLE
Block only the actual errortrace-key

### DIFF
--- a/errortrace-doc/errortrace/scribblings/errortrace.scrbl
+++ b/errortrace-doc/errortrace/scribblings/errortrace.scrbl
@@ -351,7 +351,7 @@ for use as an error display handler.}
 @defproc[(errortrace-annotate (stx any/c)) any/c]{
 
 Macro-expands and instruments the given top-level form. If the form is
-a module named @racketidfont{errortrace-key}, no instrumentation is
+the module @racketidfont{errortrace/errortrace-key}, no instrumentation is
 applied. See the signature element
 @sigelem[stacktrace/errortrace-annotate^ errortrace-annotate]
 (of @racket[stacktrace/errortrace-annotate^])
@@ -367,7 +367,7 @@ for @racket[stx]; @racket[(namespace-base-phase)] is typically the
 right value for the @racket[phase-level] argument.
 
 Unlike @racket[errortrace-annotate], there no special case for
-a module named @racketidfont{errortrace-key}. Also, if @racket[stx] is a module
+the module @racketidfont{errortrace/errortrace-key}. Also, if @racket[stx] is a module
 declaration, it is not enriched with imports to explicitly load
 Errortrace run-time support.}
 
@@ -467,7 +467,7 @@ hardwired to return @racket[null]. }
           syntax?]{
   Adds the property @racket['errortrace:annotate] to everywhere inside
   @racket[stx], and expands it.
-  If @racket[stx] is a module (but not named @racketidfont{errortrace-key}
+  If @racket[stx] is a module (but not the @racketidfont{errortrace/errortrace-key}
   module nor a @tech[#:doc '(lib "scribblings/reference/reference.scrbl")]{cross-phase persistent} module),
   calls @racketout[annotate-top] with the expanded code and inserts appropriate requires
   to the @racketidfont{errortrace-key} module.

--- a/errortrace-lib/errortrace/stacktrace.rkt
+++ b/errortrace-lib/errortrace/stacktrace.rkt
@@ -4,6 +4,7 @@
          syntax/kerncase
          syntax/stx
          syntax/source-syntax
+         syntax/modresolve
          "private/utils.rkt"
          "errortrace-key.rkt"
          (for-template racket/base "errortrace-key.rkt")
@@ -703,7 +704,7 @@
             (free-identifier=? #'mod
                                (namespace-module-identifier)
                                (namespace-base-phase)))
-       (if (eq? (syntax-e #'name) 'errortrace-key)
+       (if (equal? (syntax-source top-e) (resolve-module-path 'errortrace/errortrace-key))
            top-e
            (let ([expanded-e (do-expand top-e)])
              (cond


### PR DESCRIPTION
There's no need to block all modules named errortrace-key.
We can test if the target form is from errortrace-key by checking
syntax-source and see if it's equal resolve-module-path of
'errortrace/errortrace-key