### PR TITLE
RFC: fix (?) cross-phase-persistent submodules

### DIFF
--- a/errortrace-lib/errortrace/stacktrace.rkt
+++ b/errortrace-lib/errortrace/stacktrace.rkt
@@ -715,28 +715,22 @@
        (if (is-key-module? top-e)
            top-e
            (let ([expanded-e (do-expand top-e)])
-             (cond
-               [(has-cross-phase-declare?
-                 (syntax-case expanded-e ()
-                   [(mod name init-import mb) #'mb]))
-                expanded-e]
-               [else
-                (transform-all-modules
-                 (do-annotate top-e expanded-e)
-                 (lambda (top-e mod-id)
-                   (syntax-case top-e ()
-                     [(mod name init-import mb)
-                      (syntax-case (disarm #'mb) (#%plain-module-begin)
-                        [(#%plain-module-begin body ...)
-                         (let ([meta-depth ((count-meta-levels 0) #'(begin body ...))])
-                           (copy-props
-                            top-e
-                            #`(#,mod-id name init-import
-                                        #,(syntax-rearm
-                                           #`(#%plain-module-begin
-                                              #,(generate-key-imports-at-phase meta-depth 0 key-module-name)
-                                              body ...)
-                                           #'mb))))])])))])))]
+             (transform-all-modules
+              (do-annotate top-e expanded-e)
+              (lambda (top-e mod-id)
+                (syntax-case top-e ()
+                  [(mod name init-import mb)
+                   (syntax-case (disarm #'mb) (#%plain-module-begin)
+                     [(#%plain-module-begin body ...)
+                      (let ([meta-depth ((count-meta-levels 0) #'(begin body ...))])
+                        (copy-props
+                         top-e
+                         #`(#,mod-id name init-import
+                                     #,(syntax-rearm
+                                        #`(#%plain-module-begin
+                                           #,(generate-key-imports-at-phase meta-depth 0 key-module-name)
+                                           body ...)
+                                        #'mb))))])])))))]
       [_else
        (let ()
          (define e (do-annotate top-e (do-expand top-e)))
@@ -815,6 +809,9 @@
     (syntax-case stx ()
       [(mod name init-import mb)
        (syntax-case (disarm #'mb) (#%plain-module-begin)
+         [(#%plain-module-begin body ...)
+          (has-cross-phase-declare? #'(body ...))
+          stx]
          [(#%plain-module-begin body ...)
           (let ()
             (define ((handle-top-form phase) expr)


### PR DESCRIPTION
Summary:

Previously, errortrace left cross-phase-persistent modules alone, but the check was not applied to cross-phase-persistent submodules of root modules which were not themselves cross-phase-persistent. This moves the check inward so it is also applied to submodules.

Pending: This moves the check from `errortrace-annotate` to `transform-all-modules` which appears to do the submodule recursion, but which is also called after `do-annotate` which seems to have some implementations which also do submodule recursion. I don't understand how these are interacting and whether the submodule check needs to be earlier, or in both places, or something. Advice welcome.

Fixes https://github.com/racket/racket/issues/5351

Test Plan:

Both of these run with

    racket -l errortrace -t file.rkt

without error:

```racket
(module outer '#%kernel
  (module u '#%kernel
    (#%declare #:cross-phase-persistent)))

(module outer '#%kernel
  (#%declare #:cross-phase-persistent))
```