### PR TITLE
add errortrace-continuation-mark-set->context

### DIFF
--- a/errortrace-doc/errortrace/scribblings/errortrace.scrbl
+++ b/errortrace-doc/errortrace/scribblings/errortrace.scrbl
@@ -685,6 +685,26 @@ A parameter set by @sigelem[stacktrace/errortrace-annotate^ errortrace-annotate]
  to the expanded version of its input.
 }
 
+@section[#:tag "marks-to-context"]{Programmatically Extracting Stack-trace Information}
+
+@defmodule[errotrace/marks-to-context]{}
+
+@defparam[errortrace-continuation-mark-set->context
+          proc
+          (or/c #f (-> continuation-mark-set? (listof srcloc?)))
+          #:value (λ (x) #f)]{
+
+ Extracts the list of source locations recorded by
+ @racket[with-mark] from the given
+ @tech[#:doc '(lib "scribblings/reference/reference.scrbl")]{continuation
+  marks}, if it is a procedure. This parameter is expected to
+ be set by an instantiation of the units documented above,
+ e.g., by requiring the @racketmodname[errortrace] library or
+ by enabling @onscreen{Debugging} in DrRacket’s language
+ configuration dialog.
+
+ @history[#:added "1.6"]
+}
 
 @section{Errortrace Key}
 @defmodule[errortrace/errortrace-key]

--- a/errortrace-lib/errortrace/errortrace-lib.rkt
+++ b/errortrace-lib/errortrace/errortrace-lib.rkt
@@ -6,6 +6,7 @@
 (require "stacktrace.rkt"
          (prefix-in ek: "errortrace-key.rkt")
          "private/utils.rkt"
+         "marks-to-context.rkt"
          racket/contract/base
          racket/unit
          racket/list
@@ -401,6 +402,14 @@
             (print-error-trace p exn)
             (orig (get-output-string p) exn))
           (orig msg exn)))))
+
+(errortrace-continuation-mark-set->context
+ (let ([errortrace-lib-continuation-mark-set->context
+        (λ (marks)
+          (map st-mark-source
+               (continuation-mark-set->list marks
+                                            ek:errortrace-key)))])
+   errortrace-lib-continuation-mark-set->context))
 
 (provide/contract
  [annotate-covered-file (->* (path-string?) ((or/c string? #t #f)) void?)]

--- a/errortrace-lib/errortrace/marks-to-context.rkt
+++ b/errortrace-lib/errortrace/marks-to-context.rkt
@@ -1,0 +1,6 @@
+(module errortrace-key '#%kernel (void '#:errortrace-dont-annotate)
+
+  (#%provide errortrace-continuation-mark-set->context)
+
+  (define-values (errortrace-continuation-mark-set->context)
+    (make-parameter #f)))

--- a/errortrace-lib/info.rkt
+++ b/errortrace-lib/info.rkt
@@ -6,7 +6,7 @@
 
 (define pkg-authors '(mflatt robby florence))
 
-(define version "1.5")
+(define version "1.6")
 
 (define license
   '(Apache-2.0 OR MIT))


### PR DESCRIPTION
Add support to enable errortrace to share its stacktrace information with the instrumented program, in the spirit of `continuation-mark-set->context`.